### PR TITLE
fix tmp file name issues cause by abusing dirname()

### DIFF
--- a/src/fly_id3.c
+++ b/src/fly_id3.c
@@ -304,7 +304,7 @@ int BarFlyID3WriteFile(char const* file_path, struct id3_tag const* tag,
 	} else {
 		strncpy(tmp_file_path, file_path, TMP_FILE_PATH_LENGTH);
 		tmp_file_path[TMP_FILE_PATH_LENGTH - 1] = '\0';
-		dirname(tmp_file_path);
+		strcpy(tmp_file_path, dirname(tmp_file_path));
 		strcat(tmp_file_path, "/");
 		strcat(tmp_file_path, BAR_FLY_TMP_MP3_FILE_NAME);
 	}

--- a/src/fly_mp4.c
+++ b/src/fly_mp4.c
@@ -1928,7 +1928,7 @@ int BarFlyMp4TagWrite(BarFlyMp4Tag_t* tag, BarSettings_t const* settings)
 	} else {
 		strncpy(tmp_file_path, tag->file_path, TMP_FILE_PATH_LENGTH);
 		tmp_file_path[TMP_FILE_PATH_LENGTH - 1] = '\0';
-		dirname(tmp_file_path);
+		strcpy(tmp_file_path, dirname(tmp_file_path));
 		strcat(tmp_file_path, "/");
 		strcat(tmp_file_path, BAR_FLY_TMP_MP4_FILE_NAME);
 	}


### PR DESCRIPTION
This really is a weak fix but it takes care of the temp file issues ppl were seeing on OS X (issues #11 and #13). Should probably have proper checks and use a strn*()
