### PR TITLE
Fix writing tags on separate filesystem for mp3.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.d
+*.d.*
 *.o
 *.lo
 # vim swap files


### PR DESCRIPTION
Based off of 03d1e613d79f515428522eff9a9fe60ef285a162
Fixes #19, #30, #39, #43 for mp3.
