### PR TITLE
Just two compile fixes.

### DIFF
--- a/src/fly_id3.c
+++ b/src/fly_id3.c
@@ -25,6 +25,10 @@
  * IN THE SOFTWARE.
  */
 
+#ifndef __FreeBSD__
+#define _BSD_SOURCE /* mkstemp() */
+#endif
+
 #if defined ENABLE_MAD && ENABLE_ID3TAG
 
 #include <assert.h>

--- a/src/main.c
+++ b/src/main.c
@@ -146,11 +146,11 @@ static bool BarMainGetLoginCredentials (BarSettings_t *settings,
 
 				close (pipeFd[1]);
 				memset (passBuf, 0, sizeof (passBuf));
-				read (pipeFd[0], passBuf, sizeof (passBuf)-1);
+				ssize_t len = read (pipeFd[0], passBuf, sizeof (passBuf)-1);
 				close (pipeFd[0]);
 
 				/* drop trailing newlines */
-				ssize_t len = strlen (passBuf)-1;
+				len = strlen (passBuf)-1;
 				while (len >= 0 && passBuf[len] == '\n') {
 					passBuf[len] = '\0';
 					--len;


### PR DESCRIPTION
1) Fix mkstemp() feature test macro in fly_id3.c
2) Move ssize_t len so we don't ignore the return value of read() (squash compile warning)