### PR TITLE
Fix issue #52 for mp3 files

### DIFF
--- a/src/fly_id3.c
+++ b/src/fly_id3.c
@@ -240,8 +240,7 @@ int BarFlyID3WriteFile(char const* file_path, struct id3_tag const* tag,
 	int tmp_file = -1;
 	uint8_t audio_buffer[BAR_FLY_COPY_BLOCK_SIZE];
 	char tmp_file_path[FILENAME_MAX];
-	strncpy(tmp_file_path, settings->audioFileDir, strlen(settings->audioFileDir)+1);
-	strncat(tmp_file_path, "/pianobarfly-XXXXXX", 19+1);
+	strncat(tmp_file_path, "pianobarfly-XXXXXX", 18+1);
 	size_t read_count;
 	size_t write_count;
 


### PR DESCRIPTION
The fix for #52 only fixed the problem for m4a files. This PR applies the same fix for mp3 files.